### PR TITLE
Update grep/sed patterns for ssh-history

### DIFF
--- a/ssh-connect.sh
+++ b/ssh-connect.sh
@@ -11,7 +11,7 @@ fi
 source "$src"
 
 ssh-history() {
-  cat "$HISTFILE" | grep -E "^ssh\s" | sed -e 's/\s*$//' | sort | uniq -c | sort -nr | sed -e "s/^\s*[0-9]*\s//"
+  cat $HISTFILE | grep -E "(^|;)ssh\s[0-9A-Za-z]" | sed -e 's/\s*$//' | sed -e 's/:\s[0-9]*:[0-9]*;//' | sort | uniq -c | sort -nr | sed -e 's/^\s*[0-9]*\s//'
 }
 
 ssh-connect() {


### PR DESCRIPTION
now handles .bash_history and .zsh_history with `extended_history` enabled (closes #1)